### PR TITLE
Task 2: Design and implement StorageAdapter interface

### DIFF
--- a/src/lib/storage/context.tsx
+++ b/src/lib/storage/context.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from 'react';
+import type {
+  StorageAdapter,
+  StorageConfig,
+  StorageContextValue,
+  StorageMode,
+} from './types';
+import {
+  createStorageAdapter,
+  getStoredMode,
+  setStoredMode,
+} from './factory';
+
+const StorageContext = createContext<StorageContextValue | null>(null);
+
+interface StorageProviderProps {
+  children: ReactNode;
+}
+
+export function StorageProvider({ children }: StorageProviderProps) {
+  const [adapter, setAdapter] = useState<StorageAdapter | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [mode, setMode] = useState<StorageMode | null>(null);
+
+  // Initialize adapter from stored config on mount
+  useEffect(() => {
+    async function init() {
+      try {
+        const storedConfig = getStoredMode();
+        if (storedConfig) {
+          const newAdapter = await createStorageAdapter(storedConfig);
+          await newAdapter.connect();
+          setAdapter(newAdapter);
+          setMode(storedConfig.mode);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to initialize storage'));
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    init();
+  }, []);
+
+  const switchMode = useCallback(async (config: StorageConfig) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // Disconnect existing adapter
+      if (adapter) {
+        await adapter.disconnect();
+      }
+
+      // Create and connect new adapter
+      const newAdapter = await createStorageAdapter(config);
+      await newAdapter.connect();
+      await newAdapter.migrate();
+
+      // Persist the mode
+      setStoredMode(config);
+
+      setAdapter(newAdapter);
+      setMode(config.mode);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to switch storage mode'));
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [adapter]);
+
+  const value: StorageContextValue = {
+    adapter,
+    isLoading,
+    error,
+    mode,
+    switchMode,
+  };
+
+  return (
+    <StorageContext.Provider value={value}>
+      {children}
+    </StorageContext.Provider>
+  );
+}
+
+export function useStorage(): StorageContextValue {
+  const context = useContext(StorageContext);
+  if (!context) {
+    throw new Error('useStorage must be used within a StorageProvider');
+  }
+  return context;
+}

--- a/src/lib/storage/factory.ts
+++ b/src/lib/storage/factory.ts
@@ -1,0 +1,53 @@
+import type { StorageAdapter, StorageConfig } from './types';
+
+const STORAGE_MODE_KEY = 'financecontroll_storage_mode';
+
+export async function createStorageAdapter(
+  config: StorageConfig
+): Promise<StorageAdapter> {
+  switch (config.mode) {
+    case 'local': {
+      const { PGliteAdapter } = await import('./pglite-adapter');
+      return new PGliteAdapter();
+    }
+    case 'postgres': {
+      const { PostgresAdapter } = await import('./postgres-adapter');
+      if (!config.connectionString) {
+        throw new Error('Connection string required for postgres mode');
+      }
+      return new PostgresAdapter(config.connectionString);
+    }
+    case 'supabase': {
+      const { SupabaseAdapter } = await import('./supabase-adapter');
+      if (!config.supabaseUrl || !config.supabaseAnonKey) {
+        throw new Error('Supabase URL and anon key required for supabase mode');
+      }
+      return new SupabaseAdapter(config.supabaseUrl, config.supabaseAnonKey);
+    }
+    default:
+      throw new Error(`Unknown storage mode: ${config.mode}`);
+  }
+}
+
+export function getStoredMode(): StorageConfig | null {
+  if (typeof window === 'undefined') return null;
+
+  const stored = localStorage.getItem(STORAGE_MODE_KEY);
+  if (!stored) return null;
+
+  try {
+    return JSON.parse(stored) as StorageConfig;
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredMode(config: StorageConfig): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_MODE_KEY, JSON.stringify(config));
+}
+
+export function clearStoredMode(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(STORAGE_MODE_KEY);
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,0 +1,24 @@
+// Types
+export type {
+  StorageMode,
+  StorageConfig,
+  StorageAdapter,
+  StorageContextValue,
+  ExportedData,
+  Portfolio,
+  Asset,
+  Transaction,
+  Valuation,
+  ExchangeRate,
+} from './types';
+
+// Context
+export { StorageProvider, useStorage } from './context';
+
+// Factory
+export {
+  createStorageAdapter,
+  getStoredMode,
+  setStoredMode,
+  clearStoredMode,
+} from './factory';

--- a/src/lib/storage/pglite-adapter.ts
+++ b/src/lib/storage/pglite-adapter.ts
@@ -1,0 +1,56 @@
+import type { StorageAdapter, StorageMode, ExportedData, DrizzleDatabase } from './types';
+
+export class PGliteAdapter implements StorageAdapter {
+  private connected = false;
+  private _db: DrizzleDatabase | null = null;
+
+  get db(): DrizzleDatabase {
+    if (!this._db) {
+      throw new Error('Database not connected. Call connect() first.');
+    }
+    return this._db;
+  }
+
+  async connect(): Promise<void> {
+    // TODO: Implement in Task 3
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this._db = null;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  getMode(): StorageMode {
+    return 'local';
+  }
+
+  async migrate(): Promise<void> {
+    // TODO: Implement in Task 3
+  }
+
+  async exportData(): Promise<ExportedData> {
+    // TODO: Implement in Phase 3
+    return {
+      version: '1.0.0',
+      exportedAt: new Date().toISOString(),
+      portfolios: [],
+      assets: [],
+      transactions: [],
+      valuations: [],
+      exchangeRates: [],
+    };
+  }
+
+  async importData(_data: ExportedData): Promise<void> {
+    // TODO: Implement in Phase 3
+  }
+
+  async ping(): Promise<boolean> {
+    return this.connected;
+  }
+}

--- a/src/lib/storage/postgres-adapter.ts
+++ b/src/lib/storage/postgres-adapter.ts
@@ -1,0 +1,55 @@
+import type { StorageAdapter, StorageMode, ExportedData, DrizzleDatabase } from './types';
+
+export class PostgresAdapter implements StorageAdapter {
+  private connected = false;
+  private _db: DrizzleDatabase | null = null;
+
+  constructor(private connectionString: string) {
+    // Connection string stored for future use
+    void this.connectionString;
+  }
+
+  get db(): DrizzleDatabase {
+    if (!this._db) {
+      throw new Error('Database not connected. Call connect() first.');
+    }
+    return this._db;
+  }
+
+  async connect(): Promise<void> {
+    // TODO: Implement in Phase 5
+    throw new Error('PostgresAdapter not implemented yet');
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this._db = null;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  getMode(): StorageMode {
+    return 'postgres';
+  }
+
+  async migrate(): Promise<void> {
+    // TODO: Implement in Phase 5
+    throw new Error('PostgresAdapter not implemented yet');
+  }
+
+  async exportData(): Promise<ExportedData> {
+    // TODO: Implement in Phase 5
+    throw new Error('PostgresAdapter not implemented yet');
+  }
+
+  async importData(_data: ExportedData): Promise<void> {
+    // TODO: Implement in Phase 5
+    throw new Error('PostgresAdapter not implemented yet');
+  }
+
+  async ping(): Promise<boolean> {
+    return this.connected;
+  }
+}

--- a/src/lib/storage/supabase-adapter.ts
+++ b/src/lib/storage/supabase-adapter.ts
@@ -1,0 +1,59 @@
+import type { StorageAdapter, StorageMode, ExportedData, DrizzleDatabase } from './types';
+
+export class SupabaseAdapter implements StorageAdapter {
+  private connected = false;
+  private _db: DrizzleDatabase | null = null;
+
+  constructor(
+    private supabaseUrl: string,
+    private supabaseAnonKey: string
+  ) {
+    // Credentials stored for future use
+    void this.supabaseUrl;
+    void this.supabaseAnonKey;
+  }
+
+  get db(): DrizzleDatabase {
+    if (!this._db) {
+      throw new Error('Database not connected. Call connect() first.');
+    }
+    return this._db;
+  }
+
+  async connect(): Promise<void> {
+    // TODO: Implement in Phase 5
+    throw new Error('SupabaseAdapter not implemented yet');
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this._db = null;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  getMode(): StorageMode {
+    return 'supabase';
+  }
+
+  async migrate(): Promise<void> {
+    // TODO: Implement in Phase 5
+    throw new Error('SupabaseAdapter not implemented yet');
+  }
+
+  async exportData(): Promise<ExportedData> {
+    // TODO: Implement in Phase 5
+    throw new Error('SupabaseAdapter not implemented yet');
+  }
+
+  async importData(_data: ExportedData): Promise<void> {
+    // TODO: Implement in Phase 5
+    throw new Error('SupabaseAdapter not implemented yet');
+  }
+
+  async ping(): Promise<boolean> {
+    return this.connected;
+  }
+}

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -1,0 +1,106 @@
+export type StorageMode = 'local' | 'postgres' | 'supabase';
+
+export interface StorageConfig {
+  mode: StorageMode;
+  connectionString?: string;
+  supabaseUrl?: string;
+  supabaseAnonKey?: string;
+}
+
+// Entity types (will be fully defined with Drizzle schema)
+export interface Portfolio {
+  id: string;
+  userId: string | null;
+  name: string;
+  description: string | null;
+  baseCurrency: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Asset {
+  id: string;
+  portfolioId: string;
+  type: 'startup_equity' | 'fund' | 'state_obligation' | 'crypto' | 'public_equity' | 'other';
+  name: string;
+  ticker: string | null;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Transaction {
+  id: string;
+  assetId: string;
+  type: 'buy' | 'sell';
+  quantity: string;
+  pricePerUnit: string;
+  currency: string;
+  exchangeRate: string;
+  date: Date;
+  notes: string | null;
+  createdAt: Date;
+}
+
+export interface Valuation {
+  id: string;
+  assetId: string;
+  valuePerUnit: string;
+  currency: string;
+  exchangeRate: string;
+  valuationDate: Date;
+  source: string | null;
+  notes: string | null;
+  createdAt: Date;
+}
+
+export interface ExchangeRate {
+  id: string;
+  fromCurrency: string;
+  toCurrency: string;
+  rate: string;
+  date: Date;
+}
+
+export interface ExportedData {
+  version: string;
+  exportedAt: string;
+  portfolios: Portfolio[];
+  assets: Asset[];
+  transactions: Transaction[];
+  valuations: Valuation[];
+  exchangeRates: ExchangeRate[];
+}
+
+// Generic database type - will be specialized by each adapter
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DrizzleDatabase = any;
+
+export interface StorageAdapter {
+  // Lifecycle
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  isConnected(): boolean;
+  getMode(): StorageMode;
+
+  // Database access
+  db: DrizzleDatabase;
+
+  // Migrations
+  migrate(): Promise<void>;
+
+  // Portability
+  exportData(): Promise<ExportedData>;
+  importData(data: ExportedData): Promise<void>;
+
+  // Health check
+  ping(): Promise<boolean>;
+}
+
+export interface StorageContextValue {
+  adapter: StorageAdapter | null;
+  isLoading: boolean;
+  error: Error | null;
+  mode: StorageMode | null;
+  switchMode: (config: StorageConfig) => Promise<void>;
+}


### PR DESCRIPTION
## Summary
Create the core abstraction that enables pluggable storage backends for local-first data management.

## Changes
- StorageAdapter interface in `lib/storage/types.ts`
- React context with StorageProvider and useStorage hook
- Factory function for creating adapters based on storage mode
- Placeholder implementations for PGlite, Postgres, and Supabase adapters
- Type definitions for Portfolio, Asset, Transaction, Valuation, ExchangeRate

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)