### PR TITLE
Task 4: Create Drizzle schema (Postgres dialect)

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/lib/db/schema.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL || 'postgresql://localhost/financecontroll',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "db:generate": "drizzle-kit generate",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.3.14",

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1,0 +1,87 @@
+// Raw SQL migrations for PGlite
+// These create the tables defined in schema.ts
+
+export const migrations = `
+-- Create enums
+DO $$ BEGIN
+  CREATE TYPE asset_type AS ENUM (
+    'startup_equity',
+    'fund',
+    'state_obligation',
+    'crypto',
+    'public_equity',
+    'other'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE transaction_type AS ENUM ('buy', 'sell');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- Create portfolios table
+CREATE TABLE IF NOT EXISTS portfolios (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID,
+  name TEXT NOT NULL,
+  description TEXT,
+  base_currency TEXT NOT NULL DEFAULT 'NOK',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Create assets table
+CREATE TABLE IF NOT EXISTS assets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  portfolio_id UUID NOT NULL REFERENCES portfolios(id) ON DELETE CASCADE,
+  type asset_type NOT NULL,
+  name TEXT NOT NULL,
+  ticker TEXT,
+  notes TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Create transactions table
+CREATE TABLE IF NOT EXISTS transactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  asset_id UUID NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+  type transaction_type NOT NULL,
+  quantity DECIMAL(20, 8) NOT NULL,
+  price_per_unit DECIMAL(20, 8) NOT NULL,
+  currency TEXT NOT NULL,
+  exchange_rate DECIMAL(20, 8) NOT NULL,
+  date DATE NOT NULL,
+  notes TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Create valuations table
+CREATE TABLE IF NOT EXISTS valuations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  asset_id UUID NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+  value_per_unit DECIMAL(20, 8) NOT NULL,
+  currency TEXT NOT NULL,
+  exchange_rate DECIMAL(20, 8) NOT NULL,
+  valuation_date DATE NOT NULL,
+  source TEXT,
+  notes TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Create exchange_rates table
+CREATE TABLE IF NOT EXISTS exchange_rates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  from_currency TEXT NOT NULL,
+  to_currency TEXT NOT NULL,
+  rate DECIMAL(20, 8) NOT NULL,
+  date DATE NOT NULL
+);
+
+-- Create unique index on exchange_rates
+CREATE UNIQUE INDEX IF NOT EXISTS currency_date_idx
+ON exchange_rates(from_currency, to_currency, date);
+`;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,4 +1,134 @@
-// Placeholder schema - will be fully implemented in Task 4
-// This file enables PGliteAdapter to work before the full schema is defined
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  decimal,
+  date,
+  pgEnum,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
 
-export {};
+// Enums
+export const assetTypeEnum = pgEnum('asset_type', [
+  'startup_equity',
+  'fund',
+  'state_obligation',
+  'crypto',
+  'public_equity',
+  'other',
+]);
+
+export const transactionTypeEnum = pgEnum('transaction_type', ['buy', 'sell']);
+
+// Tables
+export const portfolios = pgTable('portfolios', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id'),
+  name: text('name').notNull(),
+  description: text('description'),
+  baseCurrency: text('base_currency').default('NOK').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const assets = pgTable('assets', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  portfolioId: uuid('portfolio_id')
+    .notNull()
+    .references(() => portfolios.id, { onDelete: 'cascade' }),
+  type: assetTypeEnum('type').notNull(),
+  name: text('name').notNull(),
+  ticker: text('ticker'),
+  notes: text('notes'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const transactions = pgTable('transactions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  assetId: uuid('asset_id')
+    .notNull()
+    .references(() => assets.id, { onDelete: 'cascade' }),
+  type: transactionTypeEnum('type').notNull(),
+  quantity: decimal('quantity', { precision: 20, scale: 8 }).notNull(),
+  pricePerUnit: decimal('price_per_unit', { precision: 20, scale: 8 }).notNull(),
+  currency: text('currency').notNull(),
+  exchangeRate: decimal('exchange_rate', { precision: 20, scale: 8 }).notNull(),
+  date: date('date').notNull(),
+  notes: text('notes'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const valuations = pgTable('valuations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  assetId: uuid('asset_id')
+    .notNull()
+    .references(() => assets.id, { onDelete: 'cascade' }),
+  valuePerUnit: decimal('value_per_unit', { precision: 20, scale: 8 }).notNull(),
+  currency: text('currency').notNull(),
+  exchangeRate: decimal('exchange_rate', { precision: 20, scale: 8 }).notNull(),
+  valuationDate: date('valuation_date').notNull(),
+  source: text('source'),
+  notes: text('notes'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const exchangeRates = pgTable(
+  'exchange_rates',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    fromCurrency: text('from_currency').notNull(),
+    toCurrency: text('to_currency').notNull(),
+    rate: decimal('rate', { precision: 20, scale: 8 }).notNull(),
+    date: date('date').notNull(),
+  },
+  (table) => [
+    uniqueIndex('currency_date_idx').on(
+      table.fromCurrency,
+      table.toCurrency,
+      table.date
+    ),
+  ]
+);
+
+// Relations
+export const portfoliosRelations = relations(portfolios, ({ many }) => ({
+  assets: many(assets),
+}));
+
+export const assetsRelations = relations(assets, ({ one, many }) => ({
+  portfolio: one(portfolios, {
+    fields: [assets.portfolioId],
+    references: [portfolios.id],
+  }),
+  transactions: many(transactions),
+  valuations: many(valuations),
+}));
+
+export const transactionsRelations = relations(transactions, ({ one }) => ({
+  asset: one(assets, {
+    fields: [transactions.assetId],
+    references: [assets.id],
+  }),
+}));
+
+export const valuationsRelations = relations(valuations, ({ one }) => ({
+  asset: one(assets, {
+    fields: [valuations.assetId],
+    references: [assets.id],
+  }),
+}));
+
+// Type exports
+export type Portfolio = typeof portfolios.$inferSelect;
+export type NewPortfolio = typeof portfolios.$inferInsert;
+export type Asset = typeof assets.$inferSelect;
+export type NewAsset = typeof assets.$inferInsert;
+export type Transaction = typeof transactions.$inferSelect;
+export type NewTransaction = typeof transactions.$inferInsert;
+export type Valuation = typeof valuations.$inferSelect;
+export type NewValuation = typeof valuations.$inferInsert;
+export type ExchangeRate = typeof exchangeRates.$inferSelect;
+export type NewExchangeRate = typeof exchangeRates.$inferInsert;

--- a/src/lib/storage/pglite-adapter.ts
+++ b/src/lib/storage/pglite-adapter.ts
@@ -2,6 +2,7 @@ import { PGlite } from '@electric-sql/pglite';
 import { drizzle } from 'drizzle-orm/pglite';
 import type { StorageAdapter, StorageMode, ExportedData, DrizzleDatabase } from './types';
 import * as schema from '../db/schema';
+import { migrations } from '../db/migrations';
 
 const DB_NAME = 'idb://financecontroll';
 
@@ -63,9 +64,8 @@ export class PGliteAdapter implements StorageAdapter {
       throw new Error('Database not connected. Call connect() first.');
     }
 
-    // Run migrations - will be implemented properly in Task 4 with full schema
-    // For now, just ensure the database is ready
-    await this.client.exec('SELECT 1');
+    // Run migrations to create all tables
+    await this.client.exec(migrations);
   }
 
   async exportData(): Promise<ExportedData> {


### PR DESCRIPTION
## Summary
Define the complete database schema using Drizzle ORM with Postgres dialect for all storage adapters.

## Changes
- Complete schema with enums (asset_type, transaction_type)
- Tables: portfolios, assets, transactions, valuations, exchange_rates
- Foreign key relationships with cascade delete
- Unique index on exchange_rates for currency/date lookup
- Drizzle relations for type-safe queries
- Type exports for all entities
- Raw SQL migrations for PGlite initialization
- Drizzle config and package.json scripts

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)