### PR TITLE
Task T4: Create MockAdapter and test providers

### DIFF
--- a/src/__tests__/helpers/index.ts
+++ b/src/__tests__/helpers/index.ts
@@ -1,0 +1,7 @@
+export { TestPGliteAdapter, createTestAdapter } from './test-adapter';
+export { createMockAdapter } from './mock-adapter';
+export {
+  TestProviders,
+  renderWithProviders,
+  createMockStorageContext,
+} from './test-providers';

--- a/src/__tests__/helpers/mock-adapter.ts
+++ b/src/__tests__/helpers/mock-adapter.ts
@@ -1,0 +1,29 @@
+import { vi } from 'vitest';
+import type { StorageAdapter, StorageMode, ExportedData } from '@/lib/storage/types';
+
+/**
+ * Fully mocked adapter for component tests.
+ * Use when you don't need real database operations.
+ */
+export function createMockAdapter(overrides: Partial<StorageAdapter> = {}): StorageAdapter {
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getMode: vi.fn().mockReturnValue('local' as StorageMode),
+    db: {} as StorageAdapter['db'],
+    migrate: vi.fn().mockResolvedValue(undefined),
+    exportData: vi.fn().mockResolvedValue({
+      version: '1.0.0',
+      exportedAt: new Date().toISOString(),
+      portfolios: [],
+      assets: [],
+      transactions: [],
+      valuations: [],
+      exchangeRates: [],
+    } satisfies ExportedData),
+    importData: vi.fn().mockResolvedValue(undefined),
+    ping: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}

--- a/src/__tests__/helpers/test-providers.tsx
+++ b/src/__tests__/helpers/test-providers.tsx
@@ -1,0 +1,56 @@
+import { type ReactNode } from 'react';
+import { render, type RenderOptions } from '@testing-library/react';
+import { type StorageContextValue } from '@/lib/storage/types';
+import { createMockAdapter } from './mock-adapter';
+
+interface TestProvidersProps {
+  children: ReactNode;
+  storageValue?: Partial<StorageContextValue>;
+}
+
+/**
+ * Wrapper component with all necessary providers for testing.
+ */
+export function TestProviders({ children, storageValue }: TestProvidersProps) {
+  // For now, just render children directly
+  // The storage context is typically mocked at the module level in component tests
+  // This wrapper can be extended in the future for other providers
+  void storageValue; // Acknowledge the parameter for future use
+  return <>{children}</>;
+}
+
+/**
+ * Default mock storage context value for testing.
+ */
+export function createMockStorageContext(
+  overrides: Partial<StorageContextValue> = {}
+): StorageContextValue {
+  return {
+    adapter: createMockAdapter(),
+    isLoading: false,
+    error: null,
+    mode: 'local',
+    switchMode: async () => {},
+    ...overrides,
+  };
+}
+
+/**
+ * Custom render function that wraps components with test providers.
+ */
+export function renderWithProviders(
+  ui: ReactNode,
+  options?: {
+    storageValue?: Partial<StorageContextValue>;
+    renderOptions?: Omit<RenderOptions, 'wrapper'>;
+  }
+) {
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <TestProviders storageValue={options?.storageValue}>
+        {children}
+      </TestProviders>
+    ),
+    ...options?.renderOptions,
+  });
+}


### PR DESCRIPTION
## Summary

- Creates `createMockAdapter()` for fully-mocked storage adapter with vi.fn() mocks
- Creates `TestProviders` component wrapper for test rendering
- Creates `renderWithProviders()` helper for custom render with providers
- Creates `createMockStorageContext()` for mock context values
- Exports all helpers from `@/__tests__/helpers`

Closes #46

## Test plan

- [x] `bun run build` passes
- [x] `bun run lint` passes (only pre-existing warnings)
- [x] mock-adapter.ts created
- [x] test-providers.tsx created
- [x] index.ts exports all helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)